### PR TITLE
Add mosaic stream view and dark dashboard

### DIFF
--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -1,4 +1,12 @@
-/* Additional styles for the dynamic EchoMosaic dashboard */
+/* Dark themed styles for the EchoMosaic dashboard */
+
+body {
+  background: #121212;
+  color: #eee;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
 
 .controls {
   margin-bottom: 1rem;
@@ -7,8 +15,12 @@
   align-items: center;
 }
 
+.controls button,
 .controls select {
-  margin-left: 0.5rem;
+  background: #2a2a2a;
+  color: #eee;
+  border: 1px solid #444;
+  padding: 0.25rem 0.5rem;
 }
 
 .dashboard-grid {
@@ -16,33 +28,53 @@
   grid-gap: 1rem;
 }
 
-.cols-1 {
-  grid-template-columns: repeat(1, 1fr);
-}
-.cols-2 {
-  grid-template-columns: repeat(2, 1fr);
-}
-.cols-3 {
-  grid-template-columns: repeat(3, 1fr);
-}
-.cols-4 {
-  grid-template-columns: repeat(4, 1fr);
-}
+.cols-1 { grid-template-columns: repeat(1, 1fr); }
+.cols-2 { grid-template-columns: repeat(2, 1fr); }
+.cols-3 { grid-template-columns: repeat(3, 1fr); }
+.cols-4 { grid-template-columns: repeat(4, 1fr); }
 
 /* Stream card adjustments */
 .stream-card {
-  border: 1px solid #ccc;
+  border: 1px solid #333;
   padding: 0.5rem;
   position: relative;
+  background: #1e1e1e;
+  color: #eee;
 }
 .stream-card h2 {
   margin-top: 0;
+}
+.stream-card h2 a {
+  color: #fff;
+  text-decoration: none;
+}
+.stream-card input,
+.stream-card select,
+.stream-card button {
+  background: #2a2a2a;
+  color: #eee;
+  border: 1px solid #444;
 }
 .remove-stream {
   position: absolute;
   top: 0.25rem;
   right: 0.25rem;
   font-size: 0.8rem;
+  background: #444;
+  color: #eee;
+  border: none;
+}
+
+/* Thumbnail picker */
+.image-picker .picker-thumbnail {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  cursor: pointer;
+  margin: 2px;
+}
+.image-picker .selected-thumb {
+  outline: 2px solid #fff;
 }
 
 /* Notepad floating window */
@@ -51,12 +83,13 @@
   bottom: 1rem;
   right: 1rem;
   width: 250px;
-  background: #f8f8f8;
-  border: 1px solid #ccc;
+  background: #1e1e1e;
+  border: 1px solid #444;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
   padding: 0.5rem;
   transition: transform 0.3s;
   max-height: 300px;
+  color: #eee;
 }
 .notepad.collapsed {
   transform: translateY(calc(100% - 1.5rem));
@@ -71,9 +104,15 @@
   width: 100%;
   height: 150px;
   box-sizing: border-box;
+  background: #2a2a2a;
+  color: #eee;
+  border: 1px solid #444;
 }
 .notepad button {
   margin-top: 0.5rem;
+  background: #2a2a2a;
+  color: #eee;
+  border: 1px solid #444;
 }
 
 /* Notification styling */

--- a/static/streams.css
+++ b/static/streams.css
@@ -1,0 +1,31 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #000;
+  color: #eee;
+}
+
+.mosaic-grid {
+  display: grid;
+  grid-gap: 4px;
+  width: 100%;
+  height: 100vh;
+  grid-auto-rows: 1fr;
+}
+
+.mosaic-grid.cols-1 { grid-template-columns: repeat(1, 1fr); }
+.mosaic-grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+.mosaic-grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+.mosaic-grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+
+.mosaic-cell {
+  position: relative;
+  overflow: hidden;
+  background: #000;
+}
+.mosaic-cell iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 
   <div class="controls">
     <button id="add-stream">Add Stream</button>
-    <label>Layout:
+    <label>Dashboard Layout:
       <select id="layout-select">
         <option value="1">1 column</option>
         <option value="2" selected>2 columns</option>
@@ -20,6 +20,15 @@
         <option value="4">4 columns</option>
       </select>
     </label>
+    <label>Stream Layout:
+      <select id="mosaic-layout-select">
+        <option value="1" {% if mosaic_settings.cols == 1 %}selected{% endif %}>1 column</option>
+        <option value="2" {% if mosaic_settings.cols == 2 %}selected{% endif %}>2 columns</option>
+        <option value="3" {% if mosaic_settings.cols == 3 %}selected{% endif %}>3 columns</option>
+        <option value="4" {% if mosaic_settings.cols == 4 %}selected{% endif %}>4 columns</option>
+      </select>
+    </label>
+    <button id="open-mosaic">View Streams</button>
   </div>
 
   <div id="dashboard-grid" class="dashboard-grid cols-2">
@@ -106,6 +115,8 @@
   const grid = document.getElementById('dashboard-grid');
   const layoutSelect = document.getElementById('layout-select');
   const addStreamBtn = document.getElementById('add-stream');
+  const mosaicLayoutSelect = document.getElementById('mosaic-layout-select');
+  const openMosaicBtn = document.getElementById('open-mosaic');
 
   function showNotification(msg) {
     notification.textContent = msg;
@@ -121,6 +132,24 @@
     grid.classList.remove('cols-1','cols-2','cols-3','cols-4');
     grid.classList.add('cols-' + cols);
   });
+
+  if (mosaicLayoutSelect) {
+    mosaicLayoutSelect.addEventListener('change', e => {
+      fetch('/mosaic-settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cols: e.target.value })
+      }).then(res => res.json()).then(() => {
+        showNotification('Stream layout updated');
+      });
+    });
+  }
+
+  if (openMosaicBtn) {
+    openMosaicBtn.addEventListener('click', () => {
+      window.open('/stream', '_blank');
+    });
+  }
 
   // Add a new stream by posting to /streams
   addStreamBtn.addEventListener('click', () => {

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>EchoMosaic Streams</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='streams.css') }}">
+</head>
+<body>
+<div id="mosaic" class="mosaic-grid cols-{{ mosaic_settings.cols }}">
+  {% for stream_id, conf in stream_settings.items() %}
+  <div class="mosaic-cell">
+    <iframe src="{{ url_for('render_stream', stream_id=stream_id) }}" allow="autoplay" loading="lazy"></iframe>
+  </div>
+  {% endfor %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Show all streams together at `/stream` using a configurable mosaic layout
- Configure stream layout from the dashboard and open the mosaic view
- Apply dark mode styling across dashboard and stream pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb2c98c40832ba24f56cdc342bbfc