### PR TITLE
Add configurable stream layouts and modernized styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,10 @@ IMAGE_DIR = "/mnt/viewers"  # Adjust if needed
 
 def default_mosaic_config():
     """Return the default configuration for the mosaic /stream page."""
-    return {"cols": 2}
+    # ``layout`` controls how streams are arranged. ``grid`` uses the
+    # classic column based approach while other values enable custom
+    # layouts (e.g. horizontal or vertical stacking).
+    return {"cols": 2, "layout": "grid"}
 
 
 def default_stream_config():
@@ -45,6 +48,10 @@ def save_settings(data):
 settings = load_settings()
 if "_mosaic" not in settings:
     settings["_mosaic"] = default_mosaic_config()
+else:
+    # Backwards compatibility for older settings files
+    settings["_mosaic"].setdefault("layout", "grid")
+    settings["_mosaic"].setdefault("cols", 2)
 
 
 def get_subfolders():
@@ -177,7 +184,9 @@ def update_stream_settings(stream_id):
 @app.route("/mosaic-settings", methods=["POST"])
 def update_mosaic_settings():
     data = request.json or {}
-    settings["_mosaic"] = {"cols": int(data.get("cols", 2))}
+    layout = data.get("layout", "grid")
+    cols = int(data.get("cols", settings.get("_mosaic", {}).get("cols", 2)))
+    settings["_mosaic"] = {"layout": layout, "cols": cols}
     save_settings(settings)
     return jsonify({"status": "success", "mosaic": settings["_mosaic"]})
 

--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -3,7 +3,7 @@
 body {
   background: #121212;
   color: #eee;
-  font-family: Arial, sans-serif;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   margin: 0;
   padding: 1rem;
 }
@@ -21,6 +21,12 @@ body {
   color: #eee;
   border: 1px solid #444;
   padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: background 0.2s, border 0.2s;
+}
+
+.controls button:hover {
+  background: #3a3a3a;
 }
 
 .dashboard-grid {
@@ -40,6 +46,8 @@ body {
   position: relative;
   background: #1e1e1e;
   color: #eee;
+  border-radius: 4px;
+  box-shadow: 0 0 6px rgba(0,0,0,0.4);
 }
 .stream-card h2 {
   margin-top: 0;
@@ -54,6 +62,12 @@ body {
   background: #2a2a2a;
   color: #eee;
   border: 1px solid #444;
+  border-radius: 4px;
+  transition: background 0.2s, border 0.2s;
+}
+
+.stream-card button:hover {
+  background: #3a3a3a;
 }
 .remove-stream {
   position: absolute;

--- a/static/streams.css
+++ b/static/streams.css
@@ -2,22 +2,51 @@ html, body {
   margin: 0;
   padding: 0;
   height: 100%;
+  overflow: hidden;
   background: #000;
   color: #eee;
+  font-family: Arial, sans-serif;
 }
 
 .mosaic-grid {
   display: grid;
-  grid-gap: 4px;
-  width: 100%;
+  gap: 4px;
+  width: 100vw;
   height: 100vh;
+  box-sizing: border-box;
   grid-auto-rows: 1fr;
 }
 
-.mosaic-grid.cols-1 { grid-template-columns: repeat(1, 1fr); }
-.mosaic-grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
-.mosaic-grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
-.mosaic-grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+.mosaic-grid.layout-grid.cols-1 { grid-template-columns: repeat(1, 1fr); }
+.mosaic-grid.layout-grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+.mosaic-grid.layout-grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+.mosaic-grid.layout-grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+
+.mosaic-grid.layout-horizontal {
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+
+.mosaic-grid.layout-vertical {
+  grid-template-columns: 1fr;
+  grid-auto-rows: 1fr;
+}
+
+.mosaic-grid.layout-focus.stream-count-6 {
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-areas:
+    "a b c"
+    "d main main"
+    "e main main";
+}
+.mosaic-grid.layout-focus.stream-count-6 .mosaic-cell:nth-child(1) { grid-area: main; }
+.mosaic-grid.layout-focus.stream-count-6 .mosaic-cell:nth-child(2) { grid-area: a; }
+.mosaic-grid.layout-focus.stream-count-6 .mosaic-cell:nth-child(3) { grid-area: b; }
+.mosaic-grid.layout-focus.stream-count-6 .mosaic-cell:nth-child(4) { grid-area: c; }
+.mosaic-grid.layout-focus.stream-count-6 .mosaic-cell:nth-child(5) { grid-area: d; }
+.mosaic-grid.layout-focus.stream-count-6 .mosaic-cell:nth-child(6) { grid-area: e; }
 
 .mosaic-cell {
   position: relative;

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,11 +21,14 @@
       </select>
     </label>
     <label>Stream Layout:
-      <select id="mosaic-layout-select">
-        <option value="1" {% if mosaic_settings.cols == 1 %}selected{% endif %}>1 column</option>
-        <option value="2" {% if mosaic_settings.cols == 2 %}selected{% endif %}>2 columns</option>
-        <option value="3" {% if mosaic_settings.cols == 3 %}selected{% endif %}>3 columns</option>
-        <option value="4" {% if mosaic_settings.cols == 4 %}selected{% endif %}>4 columns</option>
+      <select id="mosaic-layout-select" data-current-cols="{{ mosaic_settings.cols }}">
+        <option value="grid" data-cols="1" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 1 %}selected{% endif %}>Grid 1 column</option>
+        <option value="grid" data-cols="2" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 2 %}selected{% endif %}>Grid 2 columns</option>
+        <option value="grid" data-cols="3" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 3 %}selected{% endif %}>Grid 3 columns</option>
+        <option value="grid" data-cols="4" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 4 %}selected{% endif %}>Grid 4 columns</option>
+        <option value="horizontal" {% if mosaic_settings.layout == 'horizontal' %}selected{% endif %}>Horizontal Stack</option>
+        <option value="vertical" {% if mosaic_settings.layout == 'vertical' %}selected{% endif %}>Vertical Stack</option>
+        <option value="focus" {% if mosaic_settings.layout == 'focus' %}selected{% endif %}>Main + Thumbs</option>
       </select>
     </label>
     <button id="open-mosaic">View Streams</button>
@@ -135,10 +138,14 @@
 
   if (mosaicLayoutSelect) {
     mosaicLayoutSelect.addEventListener('change', e => {
+      const opt = e.target.selectedOptions[0];
+      const layout = opt.value;
+      const cols = opt.dataset.cols || mosaicLayoutSelect.dataset.currentCols;
+      mosaicLayoutSelect.dataset.currentCols = cols;
       fetch('/mosaic-settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cols: e.target.value })
+        body: JSON.stringify({ layout, cols })
       }).then(res => res.json()).then(() => {
         showNotification('Stream layout updated');
       });

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='streams.css') }}">
 </head>
 <body>
-<div id="mosaic" class="mosaic-grid cols-{{ mosaic_settings.cols }}">
+<div id="mosaic" class="mosaic-grid layout-{{ mosaic_settings.layout }} cols-{{ mosaic_settings.cols }} stream-count-{{ stream_settings|length }}">
   {% for stream_id, conf in stream_settings.items() %}
   <div class="mosaic-cell">
     <iframe src="{{ url_for('render_stream', stream_id=stream_id) }}" allow="autoplay" loading="lazy"></iframe>


### PR DESCRIPTION
## Summary
- allow mosaic to choose grid, horizontal, vertical, or focus layouts
- remove scrollbars and scale streams to full viewport
- refresh dashboard styles with softer fonts and rounded controls

## Testing
- `python -m py_compile app.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcb5905a64832b82dd4b38bbeee0be