### PR TITLE
Add picture-in-picture layout and remove stream scrollbars

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,14 @@ def default_mosaic_config():
     # ``layout`` controls how streams are arranged. ``grid`` uses the
     # classic column based approach while other values enable custom
     # layouts (e.g. horizontal or vertical stacking).
-    return {"cols": 2, "layout": "grid"}
+    return {
+        "cols": 2,
+        "layout": "grid",
+        "pip_main": None,
+        "pip_pip": None,
+        "pip_corner": "bottom-right",
+        "pip_size": 25,
+    }
 
 
 def default_stream_config():
@@ -52,6 +59,10 @@ else:
     # Backwards compatibility for older settings files
     settings["_mosaic"].setdefault("layout", "grid")
     settings["_mosaic"].setdefault("cols", 2)
+    settings["_mosaic"].setdefault("pip_main", None)
+    settings["_mosaic"].setdefault("pip_pip", None)
+    settings["_mosaic"].setdefault("pip_corner", "bottom-right")
+    settings["_mosaic"].setdefault("pip_size", 25)
 
 
 def get_subfolders():
@@ -186,7 +197,15 @@ def update_mosaic_settings():
     data = request.json or {}
     layout = data.get("layout", "grid")
     cols = int(data.get("cols", settings.get("_mosaic", {}).get("cols", 2)))
-    settings["_mosaic"] = {"layout": layout, "cols": cols}
+    mosaic = {"layout": layout, "cols": cols}
+    if layout == "pip":
+        mosaic.update({
+            "pip_main": data.get("pip_main"),
+            "pip_pip": data.get("pip_pip"),
+            "pip_corner": data.get("pip_corner", "bottom-right"),
+            "pip_size": int(data.get("pip_size", 25)),
+        })
+    settings["_mosaic"] = mosaic
     save_settings(settings)
     return jsonify({"status": "success", "mosaic": settings["_mosaic"]})
 

--- a/static/stream.css
+++ b/static/stream.css
@@ -3,6 +3,7 @@ html, body {
   padding: 0;
   background: #000;
   height: 100%;
+  overflow: hidden;
 }
 #container, img, video, iframe {
   width: 100%;

--- a/static/streams.css
+++ b/static/streams.css
@@ -21,6 +21,8 @@ html, body {
 .mosaic-grid.layout-grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
 .mosaic-grid.layout-grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
 .mosaic-grid.layout-grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+.mosaic-grid.layout-grid.cols-5 { grid-template-columns: repeat(5, 1fr); }
+.mosaic-grid.layout-grid.cols-6 { grid-template-columns: repeat(6, 1fr); }
 
 .mosaic-grid.layout-horizontal {
   grid-auto-flow: column;
@@ -32,6 +34,27 @@ html, body {
   grid-template-columns: 1fr;
   grid-auto-rows: 1fr;
 }
+
+.mosaic-grid.layout-pip {
+  position: relative;
+}
+
+.mosaic-grid.layout-pip .mosaic-cell.main {
+  width: 100%;
+  height: 100%;
+}
+
+.mosaic-grid.layout-pip .mosaic-cell.pip {
+  position: absolute;
+  width: var(--pip-size, 25%);
+  height: var(--pip-size, 25%);
+  z-index: 2;
+}
+
+.mosaic-grid.layout-pip.corner-top-left .mosaic-cell.pip { top: 1%; left: 1%; }
+.mosaic-grid.layout-pip.corner-top-right .mosaic-cell.pip { top: 1%; right: 1%; }
+.mosaic-grid.layout-pip.corner-bottom-left .mosaic-cell.pip { bottom: 1%; left: 1%; }
+.mosaic-grid.layout-pip.corner-bottom-right .mosaic-cell.pip { bottom: 1%; right: 1%; }
 
 .mosaic-grid.layout-focus.stream-count-6 {
   grid-template-columns: repeat(3, 1fr);
@@ -57,4 +80,5 @@ html, body {
   width: 100%;
   height: 100%;
   border: 0;
+  overflow: hidden;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,11 +26,41 @@
         <option value="grid" data-cols="2" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 2 %}selected{% endif %}>Grid 2 columns</option>
         <option value="grid" data-cols="3" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 3 %}selected{% endif %}>Grid 3 columns</option>
         <option value="grid" data-cols="4" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 4 %}selected{% endif %}>Grid 4 columns</option>
+        <option value="grid" data-cols="5" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 5 %}selected{% endif %}>Grid 5 columns</option>
+        <option value="grid" data-cols="6" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 6 %}selected{% endif %}>Grid 6 columns</option>
         <option value="horizontal" {% if mosaic_settings.layout == 'horizontal' %}selected{% endif %}>Horizontal Stack</option>
         <option value="vertical" {% if mosaic_settings.layout == 'vertical' %}selected{% endif %}>Vertical Stack</option>
         <option value="focus" {% if mosaic_settings.layout == 'focus' %}selected{% endif %}>Main + Thumbs</option>
+        <option value="pip" {% if mosaic_settings.layout == 'pip' %}selected{% endif %}>Picture in Picture</option>
       </select>
     </label>
+    <div id="pip-options" style="display:none;">
+      <label>Main Stream:
+        <select id="pip-main-select">
+          {% for sid, conf in stream_settings.items() %}
+          <option value="{{ sid }}" {% if mosaic_settings.pip_main == sid %}selected{% endif %}>{{ sid|capitalize }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Corner Stream:
+        <select id="pip-pip-select">
+          {% for sid, conf in stream_settings.items() %}
+          <option value="{{ sid }}" {% if mosaic_settings.pip_pip == sid %}selected{% endif %}>{{ sid|capitalize }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Corner:
+        <select id="pip-corner-select">
+          <option value="top-left" {% if mosaic_settings.pip_corner == 'top-left' %}selected{% endif %}>Top Left</option>
+          <option value="top-right" {% if mosaic_settings.pip_corner == 'top-right' %}selected{% endif %}>Top Right</option>
+          <option value="bottom-left" {% if mosaic_settings.pip_corner == 'bottom-left' %}selected{% endif %}>Bottom Left</option>
+          <option value="bottom-right" {% if mosaic_settings.pip_corner == 'bottom-right' %}selected{% endif %}>Bottom Right</option>
+        </select>
+      </label>
+      <label>Size (%):
+        <input type="number" id="pip-size-input" min="10" max="50" value="{{ mosaic_settings.pip_size or 25 }}">
+      </label>
+    </div>
     <button id="open-mosaic">View Streams</button>
   </div>
 
@@ -119,6 +149,11 @@
   const layoutSelect = document.getElementById('layout-select');
   const addStreamBtn = document.getElementById('add-stream');
   const mosaicLayoutSelect = document.getElementById('mosaic-layout-select');
+  const pipOptions = document.getElementById('pip-options');
+  const pipMainSelect = document.getElementById('pip-main-select');
+  const pipPipSelect = document.getElementById('pip-pip-select');
+  const pipCornerSelect = document.getElementById('pip-corner-select');
+  const pipSizeInput = document.getElementById('pip-size-input');
   const openMosaicBtn = document.getElementById('open-mosaic');
 
   function showNotification(msg) {
@@ -136,20 +171,43 @@
     grid.classList.add('cols-' + cols);
   });
 
-  if (mosaicLayoutSelect) {
-    mosaicLayoutSelect.addEventListener('change', e => {
-      const opt = e.target.selectedOptions[0];
-      const layout = opt.value;
-      const cols = opt.dataset.cols || mosaicLayoutSelect.dataset.currentCols;
-      mosaicLayoutSelect.dataset.currentCols = cols;
-      fetch('/mosaic-settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ layout, cols })
-      }).then(res => res.json()).then(() => {
-        showNotification('Stream layout updated');
-      });
+  function sendMosaicSettings() {
+    const opt = mosaicLayoutSelect.selectedOptions[0];
+    const layout = opt.value;
+    const cols = opt.dataset.cols || mosaicLayoutSelect.dataset.currentCols;
+    mosaicLayoutSelect.dataset.currentCols = cols;
+    const body = { layout, cols };
+    if (layout === 'pip') {
+      body.pip_main = pipMainSelect.value;
+      body.pip_pip = pipPipSelect.value;
+      body.pip_corner = pipCornerSelect.value;
+      body.pip_size = parseInt(pipSizeInput.value, 10) || 25;
+    }
+    fetch('/mosaic-settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }).then(res => res.json()).then(() => {
+      showNotification('Stream layout updated');
     });
+  }
+
+  if (mosaicLayoutSelect) {
+    const handleLayoutChange = () => {
+      const layout = mosaicLayoutSelect.value;
+      if (pipOptions) {
+        pipOptions.style.display = (layout === 'pip') ? 'block' : 'none';
+      }
+      sendMosaicSettings();
+    };
+    mosaicLayoutSelect.addEventListener('change', handleLayoutChange);
+    ['pip-main-select','pip-pip-select','pip-corner-select','pip-size-input'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.addEventListener('change', sendMosaicSettings);
+      }
+    });
+    handleLayoutChange();
   }
 
   if (openMosaicBtn) {

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -6,12 +6,25 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='streams.css') }}">
 </head>
 <body>
-<div id="mosaic" class="mosaic-grid layout-{{ mosaic_settings.layout }} cols-{{ mosaic_settings.cols }} stream-count-{{ stream_settings|length }}">
-  {% for stream_id, conf in stream_settings.items() %}
-  <div class="mosaic-cell">
-    <iframe src="{{ url_for('render_stream', stream_id=stream_id) }}" allow="autoplay" loading="lazy"></iframe>
-  </div>
-  {% endfor %}
+<div id="mosaic" class="mosaic-grid layout-{{ mosaic_settings.layout }} cols-{{ mosaic_settings.cols }} stream-count-{{ stream_settings|length }}{% if mosaic_settings.layout == 'pip' %} corner-{{ mosaic_settings.pip_corner }}{% endif %}"{% if mosaic_settings.layout == 'pip' %} style="--pip-size: {{ mosaic_settings.pip_size|default(25) }}%;"{% endif %}>
+  {% if mosaic_settings.layout == 'pip' %}
+    {% if mosaic_settings.pip_main %}
+    <div class="mosaic-cell main">
+      <iframe src="{{ url_for('render_stream', stream_id=mosaic_settings.pip_main) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+    </div>
+    {% endif %}
+    {% if mosaic_settings.pip_pip %}
+    <div class="mosaic-cell pip">
+      <iframe src="{{ url_for('render_stream', stream_id=mosaic_settings.pip_pip) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+    </div>
+    {% endif %}
+  {% else %}
+    {% for stream_id, conf in stream_settings.items() %}
+    <div class="mosaic-cell">
+      <iframe src="{{ url_for('render_stream', stream_id=stream_id) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+    </div>
+    {% endfor %}
+  {% endif %}
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Hide scrollbars in individual streams and mosaic iframes
- Support additional grid column counts and a new picture-in-picture stream layout
- Allow configuring PiP main/corner streams, position, and size from dashboard

## Testing
- ✅ `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcb94e05a0832b85fb7da35b7b4cdd