### PR TITLE
fix: persist dashboard settings and refresh mosaic clients

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,6 +207,7 @@ def update_mosaic_settings():
         })
     settings["_mosaic"] = mosaic
     save_settings(settings)
+    socketio.emit("mosaic_refresh", {"mosaic": settings["_mosaic"]})
     return jsonify({"status": "success", "mosaic": settings["_mosaic"]})
 
 @app.route("/stream/image/<path:filename>")

--- a/static/stream.css
+++ b/static/stream.css
@@ -10,4 +10,5 @@ html, body {
   height: 100%;
   object-fit: contain;
   display: block;
+  background: #000;
 }

--- a/static/streams.css
+++ b/static/streams.css
@@ -81,4 +81,6 @@ html, body {
   height: 100%;
   border: 0;
   overflow: hidden;
+  display: block;
+  background: #000;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,10 +165,17 @@
   }
 
   // Adjust grid layout
+  const savedCols = localStorage.getItem('dashboardCols');
+  if (savedCols) {
+    layoutSelect.value = savedCols;
+    grid.classList.remove('cols-1','cols-2','cols-3','cols-4');
+    grid.classList.add('cols-' + savedCols);
+  }
   layoutSelect.addEventListener('change', () => {
     const cols = layoutSelect.value;
     grid.classList.remove('cols-1','cols-2','cols-3','cols-4');
     grid.classList.add('cols-' + cols);
+    localStorage.setItem('dashboardCols', cols);
   });
 
   function sendMosaicSettings() {
@@ -419,6 +426,8 @@
           loadImagesFor(streamId, folder);
         });
       }
+
+      toggleVisibilityForMode(card, modeSelect ? modeSelect.value : '', urlInput ? urlInput.value : '');
     });
   });
 </script>

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -26,5 +26,12 @@
     {% endfor %}
   {% endif %}
 </div>
+<script src="https://cdn.socket.io/4.0.1/socket.io.min.js"></script>
+<script>
+const socket = io();
+['streams_changed', 'mosaic_refresh'].forEach(ev => {
+  socket.on(ev, () => { location.reload(); });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove stray white lines around streams by enforcing block layout and black background
- remember dashboard column layout and restore stream-specific controls on load
- auto-reload remote mosaic pages when layout or stream list changes

## Testing
- `python -m py_compile app.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcbd18e198832b86f82cbc83b895da