### PR TITLE
Reset local changes before updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ browser at `http://your‑server:PORT/`.
 To pull in new changes from GitHub and restart the running service,
 use the provided `update.sh` script. The script prompts for the
 installation directory and systemd service name, fetches the latest
-code, updates Python dependencies, and restarts the service.
+code, discards any local modifications so the working tree matches the
+remote branch, updates Python dependencies, and restarts the service.
 
 ```
 chmod +x update.sh

--- a/update.sh
+++ b/update.sh
@@ -24,7 +24,11 @@ fi
 cd "$INSTALL_DIR"
 
 echo "\nFetching latest changes from origin..."
-git pull --ff-only
+# Reset any local changes and sync with the remote branch
+git fetch origin
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+git reset --hard "origin/${current_branch}"
+git clean -fd
 
 echo "\nUpdating Python dependencies..."
 "$INSTALL_DIR/venv/bin/pip" install --upgrade -r requirements.txt


### PR DESCRIPTION
## Summary
- force update.sh to discard local modifications and sync with origin
- document that update.sh resets local changes

## Testing
- `bash -n update.sh`
- `shellcheck update.sh` *(fails: command not found)*
- `markdownlint README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc6bae02c832b96d4d202cdfe8387