### PR TITLE
Add web-based update system with settings page

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "INSTALL_DIR": "/opt/echomosaic",
+  "SERVICE_NAME": "echomosaic.service",
+  "UPDATE_BRANCH": "main",
+  "API_KEY": ""
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
 
   <div class="controls">
     <button id="add-stream">Add Stream</button>
+    <a href="{{ url_for('app_settings') }}">Settings</a>
     <label>Dashboard Layout:
       <select id="layout-select">
         <option value="1">1 column</option>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>EchoMosaic Settings</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <script>
+  function triggerUpdate() {
+    fetch('/update_app', {
+      method: 'POST',
+      headers: {
+        'X-API-Key': '{{ config.get("API_KEY", "") }}'
+      }
+    })
+    .then(res => res.text())
+    .then(html => {
+      document.body.innerHTML = html;
+    })
+    .catch(err => alert('Update failed: ' + err));
+  }
+  </script>
+</head>
+<body>
+  <div class="container">
+    <h1>Settings</h1>
+    <p><strong>Install Dir:</strong> {{ config.INSTALL_DIR }}</p>
+    <p><strong>Service Name:</strong> {{ config.SERVICE_NAME }}</p>
+    <p><strong>Update Branch:</strong> {{ config.UPDATE_BRANCH }}</p>
+    <button onclick="triggerUpdate()">Update Now</button>
+    <p><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
+  </div>
+</body>
+</html>

--- a/templates/update_status.html
+++ b/templates/update_status.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Update Status</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <script>
+    setTimeout(function(){ window.location.href = '{{ url_for('dashboard') }}'; }, 10000);
+  </script>
+</head>
+<body>
+  <div class="container">
+    <h1>Update</h1>
+    <p>{{ message }}</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add config.json for installation path, service name, branch and optional API key.
- Introduce /settings and /update_app routes with UI templates to trigger updates.
- Replace interactive update.sh with non-interactive script reading config values.
- Link new settings page from dashboard.

## Testing
- `python -m py_compile app.py main.py`
- `bash -n update.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bccd90afec832bb4dab6152708827f