### PR TITLE
Standardize EchoMosaic naming across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# EchoView Dashboard
+# EchoMosaic
 
-EchoView Dashboard is a web‑based control panel and viewer for one or more
-EchoView receivers. It provides a simple way to configure up to four
+EchoMosaic is a web‑based control panel and viewer for one or more
+EchoMosaic receivers. It provides a simple way to configure up to four
 independent streams, each of which can display images from a folder or
 play a live stream from a service such as YouTube or Twitch. The
 application is built with Flask and uses Socket.IO to update the
@@ -60,8 +60,8 @@ chmod +x update.sh
 ```
 
 By default it assumes the application is installed in
-`/opt/echoview-dashboard` and managed by the
-`echoview-dashboard.service` unit, but you can override these values
+`/opt/echomosaic` and managed by the
+`echomosaic.service` unit, but you can override these values
 when prompted.
 
 ## Manual installation

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This installation script automates the setup of the EchoView Dashboard
+# This installation script automates the setup of the EchoMosaic
 # application. It performs the following steps:
 #   1. Installs system packages required for Python and virtual environments.
 #   2. Copies the application files to a dedicated installation directory.
@@ -16,8 +16,8 @@ default_user="$(whoami)"
 read -r -p "Enter the user account that should run the service [${default_user}]: " SERVICE_USER
 SERVICE_USER="${SERVICE_USER:-$default_user}"
 
-# Prompt for installation directory (default: /opt/echoview-dashboard)
-default_install_dir="/opt/echoview-dashboard"
+# Prompt for installation directory (default: /opt/echomosaic)
+default_install_dir="/opt/echomosaic"
 read -r -p "Enter installation directory [${default_install_dir}]: " INSTALL_DIR
 INSTALL_DIR="${INSTALL_DIR:-$default_install_dir}"
 
@@ -71,7 +71,7 @@ if [[ "$mount_answer" =~ ^[Yy]$ ]]; then
   echo
   echo "Auth options:"
   echo "  1) guest (no username/password)  [default]"
-  echo "  2) username/password (stored in /etc/samba/creds-evdash)"
+  echo "  2) username/password (stored in /etc/samba/creds-echomosaic)"
   read -r -p "Choose authentication [1/2]: " AUTH_CHOICE
   AUTH_CHOICE="${AUTH_CHOICE:-1}"
 
@@ -81,7 +81,7 @@ if [[ "$mount_answer" =~ ^[Yy]$ ]]; then
   BASE_OPTS="uid=$USER_ID,gid=$GROUP_ID,iocharset=utf8,file_mode=0644,dir_mode=0755,noperm,vers=3.0,x-systemd.automount,_netdev,noauto"
 
   if [[ "$AUTH_CHOICE" == "2" ]]; then
-    CRED_FILE="/etc/samba/creds-evdash"
+    CRED_FILE="/etc/samba/creds-echomosaic"
     read -r -p "Username: " CIFS_USER
     read -r -s -p "Password: " CIFS_PASS; echo
     read -r -p "Domain (optional, ENTER to skip): " CIFS_DOMAIN
@@ -94,7 +94,7 @@ if [[ "$mount_answer" =~ ^[Yy]$ ]]; then
     sudo chmod 600 "$CRED_FILE"
     MOUNT_OPTS="credentials=$CRED_FILE,$BASE_OPTS"
   else
-    MOUNT_OPTS="guest,$BASE_OPTS"
+    MOUNT_OPTS="guest,username=guest,password=,$BASE_OPTS"
   fi
 
   echo "Creating mount dir: $MOUNT_POINT"
@@ -135,11 +135,11 @@ fi
 
 
 echo "\nCreating systemd service…"
-SERVICE_NAME="echoview-dashboard.service"
+SERVICE_NAME="echomosaic.service"
 SERVICE_PATH="/etc/systemd/system/${SERVICE_NAME}"
 sudo tee "$SERVICE_PATH" > /dev/null <<EOF
 [Unit]
-Description=EchoView Dashboard Web Application
+Description=EchoMosaic Web Application
 After=network.target
 
 [Service]
@@ -160,4 +160,4 @@ sudo systemctl enable "$SERVICE_NAME"
 sudo systemctl restart "$SERVICE_NAME"
 
 echo "\nInstallation complete!"
-echo "The EchoView Dashboard should now be accessible at http://<your-host>:$PORT/"
+echo "The EchoMosaic Dashboard should now be accessible at http://<your-host>:$PORT/"

--- a/static/style.css
+++ b/static/style.css
@@ -1,1 +1,37 @@
-/* Additional styles can be placed here. */
+/* Dark themed styles for the EchoMosaic settings page */
+
+body {
+  background: #121212;
+  color: #eee;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  background: #1e1e1e;
+  padding: 1rem;
+  border: 1px solid #333;
+  border-radius: 4px;
+  box-shadow: 0 0 6px rgba(0,0,0,0.4);
+}
+
+button {
+  background: #2a2a2a;
+  color: #eee;
+  border: 1px solid #444;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s, border 0.2s;
+}
+
+button:hover {
+  background: #3a3a3a;
+}
+
+a {
+  color: #4fa3ff;
+}


### PR DESCRIPTION
## Summary
- rename remaining EchoView references to EchoMosaic
- update installer defaults and service name to `echomosaic.service`
- add dark theme CSS for settings page and improve guest CIFS mounting

## Testing
- `bash -n install.sh`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcd6e66fe4832b82481f78a0c11354