### PR TITLE
Improve dashboard layout and unify styling

### DIFF
--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -1,51 +1,26 @@
-/* Dark themed styles for the EchoMosaic dashboard */
-
-body {
-  background: #121212;
-  color: #eee;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  margin: 0;
-  padding: 1rem;
-}
+/* Layout rules specific to the dashboard */
 
 .controls {
   margin-bottom: 1rem;
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   align-items: center;
-}
-
-.controls button,
-.controls select {
-  background: #2a2a2a;
-  color: #eee;
-  border: 1px solid #444;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  transition: background 0.2s, border 0.2s;
-}
-
-.controls button:hover {
-  background: #3a3a3a;
 }
 
 .dashboard-grid {
   display: grid;
-  grid-gap: 1rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
-
-.cols-1 { grid-template-columns: repeat(1, 1fr); }
-.cols-2 { grid-template-columns: repeat(2, 1fr); }
-.cols-3 { grid-template-columns: repeat(3, 1fr); }
-.cols-4 { grid-template-columns: repeat(4, 1fr); }
 
 /* Stream card adjustments */
 .stream-card {
-  border: 1px solid #333;
+  border: 1px solid var(--border);
   padding: 0.5rem;
   position: relative;
-  background: #1e1e1e;
-  color: #eee;
+  background: var(--surface);
+  color: var(--text);
   border-radius: 4px;
   box-shadow: 0 0 6px rgba(0,0,0,0.4);
 }
@@ -53,29 +28,16 @@ body {
   margin-top: 0;
 }
 .stream-card h2 a {
-  color: #fff;
+  color: var(--text);
   text-decoration: none;
-}
-.stream-card input,
-.stream-card select,
-.stream-card button {
-  background: #2a2a2a;
-  color: #eee;
-  border: 1px solid #444;
-  border-radius: 4px;
-  transition: background 0.2s, border 0.2s;
-}
-
-.stream-card button:hover {
-  background: #3a3a3a;
 }
 .remove-stream {
   position: absolute;
   top: 0.25rem;
   right: 0.25rem;
   font-size: 0.8rem;
-  background: #444;
-  color: #eee;
+  background: var(--surface-alt);
+  color: var(--text);
   border: none;
 }
 
@@ -88,7 +50,7 @@ body {
   margin: 2px;
 }
 .image-picker .selected-thumb {
-  outline: 2px solid #fff;
+  outline: 2px solid var(--accent);
 }
 
 /* Notepad floating window */
@@ -97,13 +59,13 @@ body {
   bottom: 1rem;
   right: 1rem;
   width: 250px;
-  background: #1e1e1e;
-  border: 1px solid #444;
+  background: var(--surface);
+  border: 1px solid var(--border);
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
   padding: 0.5rem;
   transition: transform 0.3s;
   max-height: 300px;
-  color: #eee;
+  color: var(--text);
 }
 .notepad.collapsed {
   transform: translateY(calc(100% - 1.5rem));
@@ -118,15 +80,6 @@ body {
   width: 100%;
   height: 150px;
   box-sizing: border-box;
-  background: #2a2a2a;
-  color: #eee;
-  border: 1px solid #444;
-}
-.notepad button {
-  margin-top: 0.5rem;
-  background: #2a2a2a;
-  color: #eee;
-  border: 1px solid #444;
 }
 
 /* Notification styling */

--- a/static/style.css
+++ b/static/style.css
@@ -1,37 +1,89 @@
-/* Dark themed styles for the EchoMosaic settings page */
+/* Global dark theme and component styles for EchoMosaic */
+
+:root {
+  --bg: #121212;
+  --surface: #1e1e1e;
+  --surface-alt: #2a2a2a;
+  --border: #333;
+  --border-hover: #4fa3ff;
+  --text: #eee;
+  --accent: #4fa3ff;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 
 body {
-  background: #121212;
-  color: #eee;
+  background: var(--bg);
+  color: var(--text);
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   margin: 0;
-  padding: 1rem;
+}
+
+.top-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+}
+
+.top-bar nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.top-bar a {
+  color: var(--accent);
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.top-bar a:hover {
+  background: var(--surface-alt);
 }
 
 .container {
-  max-width: 800px;
-  margin: 0 auto;
-  background: #1e1e1e;
+  max-width: 1200px;
+  margin: 1rem auto;
+  background: var(--surface);
   padding: 1rem;
-  border: 1px solid #333;
+  border: 1px solid var(--border);
   border-radius: 4px;
   box-shadow: 0 0 6px rgba(0,0,0,0.4);
 }
 
-button {
-  background: #2a2a2a;
-  color: #eee;
-  border: 1px solid #444;
-  padding: 0.5rem 1rem;
+button,
+input,
+select,
+textarea {
+  background: var(--surface-alt);
+  color: var(--text);
+  border: 1px solid var(--border);
   border-radius: 4px;
-  cursor: pointer;
+  padding: 0.4rem 0.6rem;
   transition: background 0.2s, border 0.2s;
+  font: inherit;
 }
 
-button:hover {
-  background: #3a3a3a;
+button:hover,
+input:hover,
+select:hover,
+textarea:hover,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  background: var(--surface);
+  border-color: var(--border-hover);
+  outline: none;
 }
 
 a {
-  color: #4fa3ff;
+  color: var(--accent);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,24 +3,20 @@
 <head>
   <meta charset="UTF-8"/>
   <title>EchoMosaic Dashboard</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='dashboard.css') }}">
 </head>
 <body>
+<header class="top-bar">
+  <h1>EchoMosaic</h1>
+  <nav>
+    <a href="{{ url_for('app_settings') }}">Settings</a>
+  </nav>
+</header>
 <div class="container">
-  <h1>EchoMosaic Dashboard</h1>
 
   <div class="controls">
     <button id="add-stream">Add Stream</button>
-    <a href="{{ url_for('app_settings') }}">Settings</a>
-    <label>Dashboard Layout:
-      <select id="layout-select">
-        <option value="1">1 column</option>
-        <option value="2" selected>2 columns</option>
-        <option value="3">3 columns</option>
-        <option value="4">4 columns</option>
-      </select>
-    </label>
     <label>Stream Layout:
       <select id="mosaic-layout-select" data-current-cols="{{ mosaic_settings.cols }}">
         <option value="grid" data-cols="1" {% if mosaic_settings.layout == 'grid' and mosaic_settings.cols == 1 %}selected{% endif %}>Grid 1 column</option>
@@ -65,7 +61,7 @@
     <button id="open-mosaic">View Streams</button>
   </div>
 
-  <div id="dashboard-grid" class="dashboard-grid cols-2">
+  <div id="dashboard-grid" class="dashboard-grid">
     {# Generate a card for each stream dynamically #}
     {% for stream_id, conf in stream_settings.items() %}
     <div class="stream-card" data-stream="{{ stream_id }}">
@@ -146,8 +142,6 @@
 <script>
   const socket = io();
   const notification = document.getElementById('notification');
-  const grid = document.getElementById('dashboard-grid');
-  const layoutSelect = document.getElementById('layout-select');
   const addStreamBtn = document.getElementById('add-stream');
   const mosaicLayoutSelect = document.getElementById('mosaic-layout-select');
   const pipOptions = document.getElementById('pip-options');
@@ -164,20 +158,6 @@
       notification.classList.remove('show');
     }, 3000);
   }
-
-  // Adjust grid layout
-  const savedCols = localStorage.getItem('dashboardCols');
-  if (savedCols) {
-    layoutSelect.value = savedCols;
-    grid.classList.remove('cols-1','cols-2','cols-3','cols-4');
-    grid.classList.add('cols-' + savedCols);
-  }
-  layoutSelect.addEventListener('change', () => {
-    const cols = layoutSelect.value;
-    grid.classList.remove('cols-1','cols-2','cols-3','cols-4');
-    grid.classList.add('cols-' + cols);
-    localStorage.setItem('dashboardCols', cols);
-  });
 
   function sendMosaicSettings() {
     const opt = mosaicLayoutSelect.selectedOptions[0];

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -21,13 +21,17 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <header class="top-bar">
     <h1>Settings</h1>
+    <nav>
+      <a href="{{ url_for('dashboard') }}">Dashboard</a>
+    </nav>
+  </header>
+  <div class="container">
     <p><strong>Install Dir:</strong> {{ config.INSTALL_DIR }}</p>
     <p><strong>Service Name:</strong> {{ config.SERVICE_NAME }}</p>
     <p><strong>Update Branch:</strong> {{ config.UPDATE_BRANCH }}</p>
     <button onclick="triggerUpdate()">Update Now</button>
-    <p><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce global dark theme variables and shared component styles
- Simplify dashboard with responsive grid and cohesive stream cards
- Add consistent top navigation to dashboard and settings pages

## Testing
- `python -m py_compile app.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcdb5d6754832b9ceb9e5d3b3b6ed6