### PR TITLE
Fix CSS inclusion and updater error handling

### DIFF
--- a/templates/single_stream.html
+++ b/templates/single_stream.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>{{ stream_id|capitalize }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='stream.css') }}">
 </head>
 <body>

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>EchoMosaic Streams</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='streams.css') }}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Load global style sheet on single stream and mosaic pages
- Gracefully handle missing repository path in update endpoint

## Testing
- `python -m py_compile app.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcdea9b930832bac198e2933394b55