### PR TITLE
Add group sync and server-side rendering options

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -11,7 +11,7 @@ A running list of ideas and future improvements. Add new items anywhere below.
 
 - [ ] Provide bulk toggle actions (e.g., include/exclude all).
 
-- [ ] “Slideshow sync”: sync transitions across all streams (e.g., all change every 10s together), to prevent them from changing at "random interval" when having multiple streams on one screen or near each other.
+- [x] Group sync: sync transitions across all streams (e.g., all change every 10s together), to prevent them from changing at "random interval" when having multiple streams on one screen or near each other.
 
 - [ ] Low-bandwidth mode: auto-reduces image resolution for remote access.
 
@@ -21,7 +21,7 @@ A running list of ideas and future improvements. Add new items anywhere below.
 
 - [x] add prettier update feature so user isn't hit with "This site can’t be reached <site/ip> refused to connect.
 
-- [ ] add server sided rendering as an option if possible. so it feels more like a proper stream as everyone who opens the site sees the same thing at the same time. - maybe not all streams, but the option to enable server side rendering for a specific group would be nice, if single stream is needed then the user would just make group with only one stream, hence SSR should be controlled on group level.
+- [x] add server sided rendering as an option if possible. so it feels more like a proper stream as everyone who opens the site sees the same thing at the same time. - maybe not all streams, but the option to enable server side rendering for a specific group would be nice, if single stream is needed then the user would just make group with only one stream, hence SSR should be controlled on group level.
 
 - [x] Add system monitoring, to watch cpu usage, memory usage(using/max), gpu usage(if any), storage available for media, other useful info.
 

--- a/app.py
+++ b/app.py
@@ -102,6 +102,37 @@ settings.setdefault("_notes", "")
 # Ensure groups key exists
 settings.setdefault("_groups", {})
 
+group_sync_tasks = {}
+
+def start_group_sync(name, duration, ssr, streams_conf):
+    """Start a background task to emit sync ticks for a group."""
+    if name in group_sync_tasks:
+        return
+
+    def run():
+        state = {}
+        if ssr:
+            for sid, conf in streams_conf.items():
+                imgs = list_images(conf.get("folder", "all"), shuffle=conf.get("shuffle", True))
+                state[sid] = {"imgs": imgs, "idx": 0}
+        while True:
+            payload = {"group": name}
+            if ssr:
+                payload["streams"] = {}
+                for sid, st in state.items():
+                    if not st["imgs"]:
+                        continue
+                    img = st["imgs"][st["idx"]]
+                    st["idx"] = (st["idx"] + 1) % len(st["imgs"])
+                    payload["streams"][sid] = img
+            try:
+                socketio.emit("group_tick", payload)
+            except Exception:
+                pass
+            socketio.sleep(duration)
+
+    group_sync_tasks[name] = socketio.start_background_task(run)
+
 
 def get_subfolders():
     subfolders = ["all"]
@@ -749,6 +780,8 @@ def groups_collection():
     name = (data.get("name") or "").strip()
     streams = data.get("streams") or []
     layout = data.get("layout") or None
+    sync_val = data.get("sync")
+    ssr_val = data.get("ssr")
     if not name:
         return jsonify({"error": "Name required"}), 400
     # Prevent reserved name and duplicates (case-insensitive)
@@ -759,9 +792,19 @@ def groups_collection():
         if existing.lower() == name.lower() and existing != name:
             return jsonify({"error": "Group name already exists (case-insensitive)"}), 409
     cleaned = [s for s in streams if s in settings]
-    # Store as object with streams + optional layout
+    extra = {}
     if layout and isinstance(layout, dict):
-        settings["_groups"][name] = {"streams": cleaned, "layout": layout}
+        extra["layout"] = layout
+    if sync_val is not None:
+        try:
+            extra["sync"] = int(sync_val)
+        except (TypeError, ValueError):
+            pass
+    if ssr_val:
+        extra["ssr"] = bool(ssr_val)
+    if extra:
+        extra["streams"] = cleaned
+        settings["_groups"][name] = extra
     else:
         settings["_groups"][name] = cleaned
     save_settings(settings)
@@ -796,10 +839,19 @@ def stream_group(name):
     if isinstance(group_def, dict):
         members = group_def.get("streams", [])
         g_layout = group_def.get("layout") or {}
+        sync = group_def.get("sync")
+        ssr = group_def.get("ssr", False)
     else:
         members = list(group_def)
         g_layout = {}
+        sync = None
+        ssr = False
     streams = {k: settings[k] for k in members if k in settings}
+    if sync:
+        try:
+            start_group_sync(name, int(sync), ssr, streams)
+        except Exception:
+            pass
     # Build mosaic from group layout if provided, else default
     mosaic = default_mosaic_config()
     if g_layout:
@@ -807,7 +859,7 @@ def stream_group(name):
         for k in ["layout", "cols", "rows", "pip_main", "pip_pip", "pip_corner", "pip_size", "focus_mode", "focus_pos"]:
             if k in g_layout:
                 mosaic[k] = g_layout[k]
-    return render_template("streams.html", stream_settings=streams, mosaic_settings=mosaic)
+    return render_template("streams.html", stream_settings=streams, mosaic_settings=mosaic, group_name=name, sync=sync, ssr=ssr)
 
 if __name__ == "__main__":
     socketio.run(app, host="0.0.0.0", port=5000, debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -413,3 +413,8 @@ a {
   font-size: 0.9rem;
   padding: 0.25rem 0.45rem;
 }
+.group-sync-note {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: #aaa;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,7 +98,7 @@
         <!-- Duration -->
         <div class="form-row duration-container" {% if conf.mode != 'random' %} style="display:none;" {% endif %}>
           <label for="duration-{{ stream_id }}">Duration (sec)</label>
-          <input id="duration-{{ stream_id }}" type="number" class="duration-input" data-stream="{{ stream_id }}" value="{{ conf.duration }}" min="1">
+          <input id="duration-{{ stream_id }}" type="number" class="duration-input" data-stream="{{ stream_id }}" data-base="{{ conf.duration }}" value="{{ conf.duration }}" min="1">
         </div>
 
         <!-- Stream URL -->
@@ -346,7 +346,40 @@
           groupTiles.appendChild(createGroupTile(streamsMeta, groups, name));
         });
       }
+      updateGroupSyncUI(groups);
     } catch (e) { console.error('Failed to load groups UI', e); }
+  }
+
+  function updateGroupSyncUI(groups) {
+    document.querySelectorAll('.duration-container').forEach(dc => {
+      const inp = dc.querySelector('input');
+      if (inp) {
+        inp.disabled = false;
+        if (inp.dataset.base) inp.value = inp.dataset.base;
+      }
+      const note = dc.querySelector('.group-sync-note');
+      if (note) note.remove();
+    });
+    Object.keys(groups).forEach(g => {
+      const cfg = groups[g];
+      const syncDur = cfg && (cfg.sync || cfg.sync_duration);
+      const members = Array.isArray(cfg) ? cfg : (cfg.streams || []);
+      if (syncDur) {
+        members.forEach(id => {
+          const inp = document.getElementById(`duration-${id}`);
+          if (inp) {
+            inp.disabled = true;
+            inp.value = syncDur;
+            if (!inp.parentElement.querySelector('.group-sync-note')) {
+              const sp = document.createElement('span');
+              sp.className = 'group-sync-note';
+              sp.textContent = 'controlled by Group Sync';
+              inp.parentElement.appendChild(sp);
+            }
+          }
+        });
+      }
+    });
   }
   function selectedIds(container) {
     return Array.from(container.querySelectorAll('input[type="checkbox"]:checked')).map(c=>c.value);
@@ -357,6 +390,7 @@
     const order = Array.isArray(initial) ? initial.slice() : [];
     const members = new Set(order);
     const gLayout = Array.isArray(gdata) ? {} : (gdata?.layout || {});
+    const gConf = Array.isArray(gdata) ? {} : gdata;
     const isNew = !name;
     const tile = makeEl('div', {class:'group-tile'}, []);
     const header = makeEl('div', {class:'tile-header'}, []);
@@ -419,6 +453,17 @@
     pipWrap.appendChild(rowSize);
     layoutRow.appendChild(pipWrap);
     body.appendChild(layoutRow);
+
+    const syncRow = makeEl('div', {class:'tile-row'}, [
+      makeEl('label', {}, ['Sync Duration (sec): ', makeEl('input', {type:'number', min:'1', class:'tile-sync', value: gConf.sync || ''}, [])])
+    ]);
+    body.appendChild(syncRow);
+    const ssrChk = makeEl('input', {type:'checkbox', class:'tile-ssr'}, []);
+    if (gConf.ssr) ssrChk.checked = true;
+    const ssrRow = makeEl('div', {class:'tile-row'}, [
+      makeEl('label', {}, [ssrChk, ' Server-side Rendering'])
+    ]);
+    body.appendChild(ssrRow);
 
     // Visual layout gallery
     const gallery = makeEl('div', {class:'layout-gallery'}, []);
@@ -788,7 +833,12 @@
         payloadLayout.pip_corner = pipCorner.value || 'bottom-right';
         payloadLayout.pip_size = parseInt(pipSize.value||'25',10);
       }
-      const res = await fetch('/groups', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name: nameVal, streams: ids, layout: payloadLayout})});
+      const payload = {name: nameVal, streams: ids, layout: payloadLayout};
+      const syncInput = tile.querySelector('.tile-sync');
+      const ssrInput = tile.querySelector('.tile-ssr');
+      if (syncInput && syncInput.value) payload.sync = parseInt(syncInput.value,10);
+      if (ssrInput && ssrInput.checked) payload.ssr = true;
+      const res = await fetch('/groups', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
       if (res.ok) {
         showNotification('Saved group');
         // If renamed, delete the old group name
@@ -1021,6 +1071,7 @@
       if (durInput) {
         durInput.addEventListener('change', e => {
           saveSettings(streamId, { duration: e.target.value });
+          e.target.dataset.base = e.target.value;
         });
       }
       // Shuffle change

--- a/templates/single_stream.html
+++ b/templates/single_stream.html
@@ -13,6 +13,20 @@
 const streamId = "{{ stream_id }}";
 const socket = io();
 let rotationTimer = null;
+let imgs = [];
+let idx = 0;
+const params = new URLSearchParams(location.search);
+const syncGroup = params.get('group');
+const useSSR = params.get('ssr') === '1';
+let pendingTick = false;
+
+function showImage(path) {
+  const container = document.getElementById('container');
+  container.innerHTML = '';
+  const img = document.createElement('img');
+  img.src = `/stream/image/${path}`;
+  container.appendChild(img);
+}
 
 function render(config) {
   const container = document.getElementById('container');
@@ -56,25 +70,56 @@ function render(config) {
   } else if (config.mode === 'random') {
     const folder = config.folder || 'all';
     const shuffleParam = (config.shuffle === false) ? 0 : 1;
-    fetch(`/images?folder=${encodeURIComponent(folder)}&shuffle=${shuffleParam}`)
-      .then(r => r.json())
-      .then(imgs => {
-        if (!imgs.length) {
-          container.textContent = 'No images available';
-          return;
-        }
-        let idx = 0;
-        function showNext() {
+    if (syncGroup) {
+      if (!useSSR) {
+        fetch(`/images?folder=${encodeURIComponent(folder)}&shuffle=${shuffleParam}`)
+          .then(r => r.json())
+          .then(list => {
+            imgs = list;
+            idx = 0;
+            if (pendingTick && imgs.length) {
+              pendingTick = false;
+              const path = imgs[idx];
+              idx = (idx + 1) % imgs.length;
+              showImage(path);
+            }
+          });
+      }
+      socket.off('group_tick');
+      socket.on('group_tick', data => {
+        if (data.group !== syncGroup) return;
+        if (useSSR) {
+          const path = data.streams && data.streams[streamId];
+          if (path) showImage(path);
+        } else {
+          if (!imgs.length) {
+            pendingTick = true;
+            return;
+          }
           const path = imgs[idx];
           idx = (idx + 1) % imgs.length;
-          container.innerHTML = '';
-          const img = document.createElement('img');
-          img.src = `/stream/image/${path}`;
-          container.appendChild(img);
+          showImage(path);
         }
-        showNext();
-        rotationTimer = setInterval(showNext, (config.duration || 5) * 1000);
       });
+    } else {
+      fetch(`/images?folder=${encodeURIComponent(folder)}&shuffle=${shuffleParam}`)
+        .then(r => r.json())
+        .then(list => {
+          if (!list.length) {
+            container.textContent = 'No images available';
+            return;
+          }
+          imgs = list;
+          idx = 0;
+          function showNext() {
+            const path = imgs[idx];
+            idx = (idx + 1) % imgs.length;
+            showImage(path);
+          }
+          showNext();
+          rotationTimer = setInterval(showNext, (config.duration || 5) * 1000);
+        });
+    }
   } else {
     container.textContent = 'No content configured';
   }

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -8,6 +8,11 @@
 </head>
 <body>
 {% set style_parts = [] %}
+{% set extra_qs = '' %}
+{% if group_name %}
+  {% set extra_qs = '?group=' ~ group_name %}
+  {% if ssr %}{% set extra_qs = extra_qs ~ '&ssr=1' %}{% endif %}
+{% endif %}
 {% if mosaic_settings.layout == 'pip' %}
   {% set _ = style_parts.append('--pip-size: ' ~ (mosaic_settings.pip_size|default(25)) ~ '%') %}
 {% endif %}
@@ -20,12 +25,12 @@
   {% if mosaic_settings.layout == 'pip' %}
     {% if mosaic_settings.pip_main %}
     <div class="mosaic-cell main">
-      <iframe src="{{ url_for('render_stream', name=mosaic_settings.pip_main) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+      <iframe src="{{ url_for('render_stream', name=mosaic_settings.pip_main) }}{{ extra_qs }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
     </div>
     {% endif %}
     {% if mosaic_settings.pip_pip %}
     <div class="mosaic-cell pip">
-      <iframe src="{{ url_for('render_stream', name=mosaic_settings.pip_pip) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+      <iframe src="{{ url_for('render_stream', name=mosaic_settings.pip_pip) }}{{ extra_qs }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
     </div>
     {% endif %}
   {% else %}
@@ -83,7 +88,7 @@
         {% set conf = stream_settings[stream_id] %}
         {% set area = slots[i] %}
         <div class="mosaic-cell" style="grid-area: {{ area }};">
-          <iframe src="{{ url_for('render_stream', name=(conf.label if conf.label else stream_id)|slugify) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+          <iframe src="{{ url_for('render_stream', name=(conf.label if conf.label else stream_id)|slugify) }}{{ extra_qs }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
         </div>
       {% endfor %}
       </div>
@@ -94,13 +99,13 @@
         {% set items = items[:limit] if limit else items %}
         {% for stream_id, conf in items %}
         <div class="mosaic-cell">
-          <iframe src="{{ url_for('render_stream', name=(conf.label if conf.label else stream_id)|slugify) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+          <iframe src="{{ url_for('render_stream', name=(conf.label if conf.label else stream_id)|slugify) }}{{ extra_qs }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
         </div>
         {% endfor %}
       {% else %}
         {% for stream_id, conf in stream_settings.items() %}
         <div class="mosaic-cell">
-          <iframe src="{{ url_for('render_stream', name=(conf.label if conf.label else stream_id)|slugify) }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
+          <iframe src="{{ url_for('render_stream', name=(conf.label if conf.label else stream_id)|slugify) }}{{ extra_qs }}" allow="autoplay" loading="lazy" scrolling="no"></iframe>
         </div>
         {% endfor %}
       {% endif %}


### PR DESCRIPTION
## Summary
- Fix blank group streams by queueing group ticks until images load
- Default server-side rendering to off and show accurate checkboxes
- Restore stream durations when group sync is disabled

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c09ad9996c832b873f90033243b99d